### PR TITLE
change go-to filename for s3 check | update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ Add params in config file (**`healthcheck.php`**) to add more db connections or 
         ]
     ],
 ```
+If you **connect to an s3 bucket**, make sure to add an empty "healthcheck.txt" file in its root, as it's the file the package will check against.

--- a/src/Http/Models/S3Checker.php
+++ b/src/Http/Models/S3Checker.php
@@ -22,7 +22,7 @@ class S3Checker implements CheckerInterface
         $status = new Status(Service::S3 . '/' . $this->diskName);
 
         try {
-            Storage::disk($this->diskName)->exists('file.txt');
+            Storage::disk($this->diskName)->exists('healthcheck.txt');
         } catch (Exception $e) {
             Log::error($e->getMessage());
             $status->setAvailable(false);


### PR DESCRIPTION
When the health-check package is set to (also) check an s3 bucket, the way it does that is by checking the existence of a "file.txt" in the bucket's root. To avoid future wild goose chases when the checks start failing, this information is now documented.

As a "file.txt" file can easily be mistaken as a leftover test or other garbage, the lookup file name was changed to "healthcheck.txt" to hopefully prevent accidental deletions.
